### PR TITLE
update Tesseract and Modern Industrialization dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ mod_description=Hostile Neural Networks meets Modern Industrialization...\n\nThe
 
 # Dependencies
 grandpower_version=3.0.0
-modern_industrialization_version=2.3.14
-tesseract_version=1.9.2-1.21.1
+modern_industrialization_version=2.3.16
+tesseract_version=1.10.2-1.21.1
 placebo_version=6751290
 hnn_version=6751495
 emi_version=1.1.22+1.21.1
@@ -38,5 +38,5 @@ jei_version=19.22.0.315
 guideme_version=21.1.9
 ## Ranges
 modern_industrialization_version_range=[2.3.14,)
-tesseract_version_range=[1.9.6-, 1.10-)
+tesseract_version_range=[1.10.1-,)
 hnn_version_range=[6.3.0,)


### PR DESCRIPTION
Just updated some dependencies to get the mod compatible with Extended Industrialization and Industrialization Overdrive once again.

Thankfully this seemed to just work out of the box when I tested it, so it's a pretty painless change.